### PR TITLE
Issue 13: QR Codes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "aho-corasick"
 version = "0.7.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +97,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bit_field"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dcb6dd1c2376d2e096796e234a70e17e94cc2d5d54ff8ce42b28cef1d0d359a4"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -101,6 +113,18 @@ name = "bumpalo"
 version = "3.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "572f695136211188308f16ad2ca5c851a712c464060ae6974944458eb83880ba"
+
+[[package]]
+name = "bytemuck"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aaa3a8d9a1ca92e282c96a32d6511b695d7d994d1d102ba85d279f9b2756947f"
+
+[[package]]
+name = "byteorder"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -179,10 +203,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if",
+]
 
 [[package]]
 name = "crossbeam-channel"
@@ -195,6 +234,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "715e8152b692bba2d374b53d4875445368fdf21a94751410af607a5ac677d1fc"
+dependencies = [
+ "cfg-if",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f916dfc5d356b0ed9dae65f1db9fc9770aa2851d2662b988ccf4fe3516e86348"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "crossbeam-utils",
+ "memoffset",
+ "scopeguard",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -202,6 +265,12 @@ checksum = "edbafec5fa1f196ca66527c1b12c2ec4745ca14b50f1ad8f9f6f720b55d11fac"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "cxx"
@@ -270,6 +339,44 @@ name = "either"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
+
+[[package]]
+name = "exr"
+version = "1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8eb5f255b5980bb0c8cf676b675d1a99be40f316881444f44e0462eaf5df5ded"
+dependencies = [
+ "bit_field",
+ "flume",
+ "half",
+ "lebe",
+ "miniz_oxide 0.6.2",
+ "smallvec",
+ "threadpool",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.5.4",
+]
+
+[[package]]
+name = "flume"
+version = "0.10.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1657b4441c3403d9f7b3409e47575237dac27b1b5726df654a6ecbf92f0f7577"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "nanorand",
+ "pin-project",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -382,8 +489,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c05aeb6a22b8f62540c194aac980f2115af067bfe15a0734d7277a768d396b31"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "gif"
+version = "0.11.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3edd93c6756b4dfaf2709eafcc345ba2636565295c198a9cfbf75fa5e3e00b06"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "half"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad6a9459c9c30b177b925162351f97e7d967c7ea8bab3b8352805327daf45554"
+dependencies = [
+ "crunchy",
 ]
 
 [[package]]
@@ -399,6 +527,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "html-escape"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15315cfa9503e9aa85a477138eff76a1b203a430703548052c330b69d8d8c205"
+dependencies = [
+ "utf8-width",
 ]
 
 [[package]]
@@ -505,6 +642,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.24.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b7ea949b537b0fd0af141fff8c77690f2ce96f4f41f042ccb6c69c6c965945"
+dependencies = [
+ "bytemuck",
+ "byteorder",
+ "color_quant",
+ "exr",
+ "gif",
+ "jpeg-decoder",
+ "num-rational",
+ "num-traits",
+ "png",
+ "scoped_threadpool",
+ "tiff",
+]
+
+[[package]]
 name = "itertools"
 version = "0.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +676,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "jpeg-decoder"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0000e42512c92e31c2252315bda326620a4e034105e900c98ec492fa077b3e"
+dependencies = [
+ "rayon",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +698,12 @@ name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
+
+[[package]]
+name = "lebe"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03087c2bad5e1034e8cace5926dec053fb3790248370865f5117a7d0213354c8"
 
 [[package]]
 name = "libc"
@@ -590,10 +761,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mime"
 version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96590ba8f175222643a85693f33d26e9c8a015f599c216509b1a6894af675d34"
+dependencies = [
+ "adler",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b275950c28b37e794e8c55d88aeb5e139d0ce23fdbbeda68f8d7174abdf9e8fa"
+dependencies = [
+ "adler",
+]
 
 [[package]]
 name = "mio"
@@ -605,6 +803,15 @@ dependencies = [
  "log",
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys",
+]
+
+[[package]]
+name = "nanorand"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a51313c5820b0b02bd422f4b44776fbf47961755c74ce64afc73bfad10226c3"
+dependencies = [
+ "getrandom",
 ]
 
 [[package]]
@@ -624,6 +831,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "225d3389fb3509a24c93f5c29eb6bde2586b98d9f016636dff58d7c6f7569cd9"
 dependencies = [
  "autocfg",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0638a1c9d0a3c0914158145bc76cff373a75a627e6ecbfb71cbe6f453a5a19b0"
+dependencies = [
+ "autocfg",
+ "num-integer",
  "num-traits",
 ]
 
@@ -729,6 +947,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "png"
+version = "0.17.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d708eaf860a19b19ce538740d2b4bdeeb8337fa53f7738455e706623ad5c638"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "flate2",
+ "miniz_oxide 0.6.2",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -762,12 +992,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode-generator"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501c33c9127afb867693646b38817bf63a9a756d4b66aefbc5c0d7e5e8c3125a"
+dependencies = [
+ "html-escape",
+ "image",
+ "qrcodegen",
+]
+
+[[package]]
+name = "qrcodegen"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4339fc7a1021c9c1621d87f5e3505f2805c8c105420ba2f2a4df86814590c142"
+
+[[package]]
 name = "quote"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
 dependencies = [
  "proc-macro2",
+]
+
+[[package]]
+name = "rayon"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd99e5772ead8baa5215278c9b15bf92087709e9c1b2d1f97cdb5a183c933a7d"
+dependencies = [
+ "autocfg",
+ "crossbeam-deque",
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "258bcdb5ac6dad48491bb2992db6b7cf74878b0384908af124823d118c99683f"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-deque",
+ "crossbeam-utils",
+ "num_cpus",
 ]
 
 [[package]]
@@ -838,6 +1109,12 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "scoped_threadpool"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d51f5df5af43ab3f1360b429fa5e0152ac5ce8c0bd6485cae490332e96846a8"
 
 [[package]]
 name = "scopeguard"
@@ -999,6 +1276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6002a767bff9e83f8eeecf883ecb8011875a21ae8da43bffb817a57e78cc09"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1079,6 +1365,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5516c27b78311c50bf42c071425c560ac799b11c30b31f87e3081965fe5e0180"
 dependencies = [
  "once_cell",
+]
+
+[[package]]
+name = "threadpool"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
+dependencies = [
+ "num_cpus",
+]
+
+[[package]]
+name = "tiff"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17def29300a156c19ae30814710d9c63cd50288a49c6fd3a10ccfbe4cf886fd"
+dependencies = [
+ "flate2",
+ "jpeg-decoder",
+ "weezl",
 ]
 
 [[package]]
@@ -1283,6 +1589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+
+[[package]]
 name = "uuid"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1379,6 +1691,12 @@ name = "wasm-bindgen-shared"
 version = "0.2.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c38c045535d93ec4f0b4defec448e4291638ee608530863b1e2ba115d4fff7f"
+
+[[package]]
+name = "weezl"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
 
 [[package]]
 name = "winapi"
@@ -1478,6 +1796,7 @@ dependencies = [
  "dateparser",
  "humantime",
  "icalendar",
+ "qrcode-generator",
  "shuttle-service",
  "sync_wrapper",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ chrono = "0.4.22"
 dateparser = "0.1.7"
 humantime = "2.1.0"
 icalendar = "0.13.2"
+qrcode-generator = "4.1.6"
 shuttle-service = { version = "0.7.2", features = ["web-axum"], optional = true }
 sync_wrapper = "0.1.1"
 tokio = { version = "1.20.1", features = ["full"], optional = true }

--- a/src/bin.rs
+++ b/src/bin.rs
@@ -1,13 +1,4 @@
 #[cfg(feature = "local")]
-use axum::{
-    routing::{get, post},
-    Router,
-};
-
-#[cfg(feature = "local")]
-use zerocal::calendar;
-
-#[cfg(feature = "local")]
 use std::net::SocketAddr;
 
 #[cfg(feature = "local")]
@@ -16,9 +7,7 @@ use anyhow::Result;
 #[cfg(feature = "local")]
 #[tokio::main]
 async fn main() -> Result<()> {
-    let router = Router::new()
-        .route("/", get(calendar))
-        .route("/", post(calendar));
+    let router = zerocal::get_router();
     let addr = SocketAddr::from(([127, 0, 0, 1], 8000));
     axum::Server::bind(&addr)
         .serve(router.into_make_service())

--- a/src/cal.rs
+++ b/src/cal.rs
@@ -1,0 +1,90 @@
+use anyhow::Result;
+use icalendar::*;
+use std::collections::HashMap;
+
+use crate::time::{parse_duration, parse_time};
+
+
+pub struct CalendarParseError {
+    pub err: String,
+}
+const DEFAULT_EVENT_TITLE: &str = "New Calendar Event";
+
+
+pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, CalendarParseError> {
+    let mut event = Event::new();
+
+    if let Some(title) = params.get("title") {
+        event.summary(title);
+    } else {
+        event.summary(DEFAULT_EVENT_TITLE);
+    }
+    if let Some(desc) = params.get("desc") {
+        event.description(desc);
+    } else {
+        event.description("Powered by zerocal.shuttleapp.rs");
+    }
+
+    match params.get("start") {
+        Some(start) if !start.is_empty() => {
+            let start = match parse_time(start) {
+                Ok(start) => start,
+                Err(e) => {
+                    return Err(CalendarParseError{err: format!("Invalid start time: {}", e)});
+                }
+            };
+            event.starts(start);
+            if let Some(duration) = params.get("duration") {
+                let duration = match parse_duration(duration) {
+                    Ok(duration) => duration,
+                    Err(e) => {
+                        return Err(CalendarParseError{err: format!("Invalid duration: {}", e)});
+                    }
+                };
+                event.ends(start + duration);
+            }
+        }
+        _ => {
+            // start is not set or empty; default to 1 hour event
+            event.starts(chrono::Utc::now());
+            event.ends(chrono::Utc::now() + chrono::Duration::hours(1));
+        }
+    }
+
+    match params.get("end") {
+        Some(end) if !end.is_empty() => {
+            let end = match parse_time(end) {
+                Ok(end) => end,
+                Err(e) => {
+                    return Err(CalendarParseError{err: format!("Invalid end time: {}", e)});
+                }
+            };
+            event.ends(end);
+            if let Some(duration) = params.get("duration") {
+                if params.get("start").is_none() {
+                    // If only duration is given but no start, set start to end - duration
+                    let duration = match parse_duration(duration) {
+                        Ok(duration) => duration,
+                        Err(e) => {
+                            return Err(CalendarParseError{err: format!("Invalid duration: {}", e)});
+                        }
+                    };
+                    event.starts(end - duration);
+                }
+            }
+        }
+        _ => {
+            // end is not set or empty; default to 1 hour event
+            // TODO: handle case where start is set
+            event.starts(chrono::Utc::now());
+            event.ends(chrono::Utc::now() + chrono::Duration::hours(1));
+        }
+    }
+
+    if let Some(location) = params.get("location") {
+        event.location(location);
+    }
+
+    Ok(Calendar::new().push(event.done()).done())
+
+}

--- a/src/cal.rs
+++ b/src/cal.rs
@@ -43,19 +43,16 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar> {
         .map_or(Ok(None), |r| r.map(Some))
         .map_err(|e| e.context("Invalid duration"))?;
 
-    let (start, end) = match (start, end, duration) {
+    let (start, end) = match (start, end, duration.unwrap_or(DEFAULT_EVENT_DURATION)) {
         // If start + end + duration given, ignore duration (or assume it's correct).
         (Some(start), Some(end), _) => (start, end),
 
         // If given either start or end, use that plus duration (or default duration).
-        (Some(start), None, dur) => (start, start + dur.unwrap_or(DEFAULT_EVENT_DURATION)),
-        (None, Some(end), dur) => (end - dur.unwrap_or(DEFAULT_EVENT_DURATION), end),
+        (Some(start), None, dur) => (start, start + dur),
+        (None, Some(end), dur) => (end - dur, end),
 
         // If not given a start or an end, use now() and duration (or default duration).
-        (None, None, dur) => (
-            chrono::Utc::now(),
-            chrono::Utc::now() + dur.unwrap_or(DEFAULT_EVENT_DURATION),
-        ),
+        (None, None, dur) => (chrono::Utc::now(), chrono::Utc::now() + dur),
     };
     event.starts(start);
     event.ends(end);

--- a/src/cal.rs
+++ b/src/cal.rs
@@ -4,26 +4,31 @@ use std::collections::HashMap;
 
 use crate::time::{parse_duration, parse_time};
 
-pub struct CalendarParseError {
-    pub err: String,
-}
 const DEFAULT_EVENT_TITLE: &str = "New Calendar Event";
 const DEFAULT_DESCRIPTION: &str = "Powered by zerocal.shuttleapp.rs";
 
-pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, CalendarParseError> {
+pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar> {
     let mut event = Event::new();
 
-    event.summary(params.get("title").map(String::as_str).unwrap_or(DEFAULT_EVENT_TITLE));
-    event.description(params.get("desc").map(String::as_str).unwrap_or(DEFAULT_DESCRIPTION));
+    event.summary(
+        params
+            .get("title")
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_EVENT_TITLE),
+    );
+    event.description(
+        params
+            .get("desc")
+            .map(String::as_str)
+            .unwrap_or(DEFAULT_DESCRIPTION),
+    );
 
     match params.get("start") {
         Some(start) if !start.is_empty() => {
             let start = match parse_time(start) {
                 Ok(start) => start,
                 Err(e) => {
-                    return Err(CalendarParseError {
-                        err: format!("Invalid start time: {}", e),
-                    });
+                    return Err(e.context("Invalid start time"));
                 }
             };
             event.starts(start);
@@ -31,9 +36,7 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
                 let duration = match parse_duration(duration) {
                     Ok(duration) => duration,
                     Err(e) => {
-                        return Err(CalendarParseError {
-                            err: format!("Invalid duration: {}", e),
-                        });
+                        return Err(e.context("Invalid duration"));
                     }
                 };
                 event.ends(start + duration);
@@ -51,9 +54,7 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
             let end = match parse_time(end) {
                 Ok(end) => end,
                 Err(e) => {
-                    return Err(CalendarParseError {
-                        err: format!("Invalid end time: {}", e),
-                    });
+                    return Err(e.context("Invalid end time"));
                 }
             };
             event.ends(end);
@@ -63,9 +64,7 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
                     let duration = match parse_duration(duration) {
                         Ok(duration) => duration,
                         Err(e) => {
-                            return Err(CalendarParseError {
-                                err: format!("Invalid duration: {}", e),
-                            });
+                            return Err(e.context("Invalid duration"));
                         }
                     };
                     event.starts(end - duration);

--- a/src/cal.rs
+++ b/src/cal.rs
@@ -8,20 +8,13 @@ pub struct CalendarParseError {
     pub err: String,
 }
 const DEFAULT_EVENT_TITLE: &str = "New Calendar Event";
+const DEFAULT_DESCRIPTION: &str = "Powered by zerocal.shuttleapp.rs";
 
 pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, CalendarParseError> {
     let mut event = Event::new();
 
-    if let Some(title) = params.get("title") {
-        event.summary(title);
-    } else {
-        event.summary(DEFAULT_EVENT_TITLE);
-    }
-    if let Some(desc) = params.get("desc") {
-        event.description(desc);
-    } else {
-        event.description("Powered by zerocal.shuttleapp.rs");
-    }
+    event.summary(params.get("title").map(String::as_str).unwrap_or(DEFAULT_EVENT_TITLE));
+    event.description(params.get("desc").map(String::as_str).unwrap_or(DEFAULT_DESCRIPTION));
 
     match params.get("start") {
         Some(start) if !start.is_empty() => {

--- a/src/cal.rs
+++ b/src/cal.rs
@@ -4,12 +4,10 @@ use std::collections::HashMap;
 
 use crate::time::{parse_duration, parse_time};
 
-
 pub struct CalendarParseError {
     pub err: String,
 }
 const DEFAULT_EVENT_TITLE: &str = "New Calendar Event";
-
 
 pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, CalendarParseError> {
     let mut event = Event::new();
@@ -30,7 +28,9 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
             let start = match parse_time(start) {
                 Ok(start) => start,
                 Err(e) => {
-                    return Err(CalendarParseError{err: format!("Invalid start time: {}", e)});
+                    return Err(CalendarParseError {
+                        err: format!("Invalid start time: {}", e),
+                    });
                 }
             };
             event.starts(start);
@@ -38,7 +38,9 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
                 let duration = match parse_duration(duration) {
                     Ok(duration) => duration,
                     Err(e) => {
-                        return Err(CalendarParseError{err: format!("Invalid duration: {}", e)});
+                        return Err(CalendarParseError {
+                            err: format!("Invalid duration: {}", e),
+                        });
                     }
                 };
                 event.ends(start + duration);
@@ -56,7 +58,9 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
             let end = match parse_time(end) {
                 Ok(end) => end,
                 Err(e) => {
-                    return Err(CalendarParseError{err: format!("Invalid end time: {}", e)});
+                    return Err(CalendarParseError {
+                        err: format!("Invalid end time: {}", e),
+                    });
                 }
             };
             event.ends(end);
@@ -66,7 +70,9 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
                     let duration = match parse_duration(duration) {
                         Ok(duration) => duration,
                         Err(e) => {
-                            return Err(CalendarParseError{err: format!("Invalid duration: {}", e)});
+                            return Err(CalendarParseError {
+                                err: format!("Invalid duration: {}", e),
+                            });
                         }
                     };
                     event.starts(end - duration);
@@ -86,5 +92,4 @@ pub fn create_calendar(params: HashMap<String, String>) -> Result<Calendar, Cale
     }
 
     Ok(Calendar::new().push(event.done()).done())
-
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,15 +16,16 @@ use std::collections::HashMap;
 #[cfg(feature = "shuttle")]
 use sync_wrapper::SyncWrapper;
 
+mod cal;
 mod time;
-
-use time::{parse_duration, parse_time};
-
-const DEFAULT_EVENT_TITLE: &str = "New Calendar Event";
 
 /// Newtype wrapper around Calendar for `IntoResponse` impl
 #[derive(Debug)]
 pub struct CalendarResponse(pub Calendar);
+pub struct BytesResponse {
+    pub bytes: Vec<u8>,
+    pub content_type: &'static str,
+}
 
 impl IntoResponse for CalendarResponse {
     fn into_response(self) -> Response {
@@ -37,12 +38,38 @@ impl IntoResponse for CalendarResponse {
     }
 }
 
+impl IntoResponse for BytesResponse {
+    fn into_response(self) -> Response {
+        let mut res = Response::new(boxed(Full::from(self.bytes)));
+        res.headers_mut().insert(header::CONTENT_TYPE, HeaderValue::from_static(self.content_type));
+        res
+    }
+}
+
 /// Helper function to return a `BAD_REQUEST` status code with a custom message
 fn bad_request(body: String) -> Response {
     Response::builder()
         .status(StatusCode::BAD_REQUEST)
         .body(boxed(Full::from(body)))
         .unwrap()
+}
+
+pub async fn qr(Query(params): Query<HashMap<String, String>>) -> impl IntoResponse {
+    // Get calendar
+    let cal = match cal::create_calendar(params) {
+        Ok(cal) => cal,
+        Err(e) => { return bad_request(e.err); }
+    };
+
+    let qr = match qrcode_generator::to_png_to_vec(cal.to_string(), qrcode_generator::QrCodeEcc::Medium, 256) {
+        Ok(qr) => qr,
+        Err(e) => { return bad_request(format!("Failed to turn calendar into qr code: {}", e)); }
+    };
+
+    BytesResponse{
+        bytes: qr,
+        content_type: "image/png",
+    }.into_response()
 }
 
 pub async fn calendar(Query(params): Query<HashMap<String, String>>) -> impl IntoResponse {
@@ -54,91 +81,26 @@ pub async fn calendar(Query(params): Query<HashMap<String, String>>) -> impl Int
             .unwrap();
     }
 
-    let mut event = Event::new();
-
-    if let Some(title) = params.get("title") {
-        event.summary(title);
-    } else {
-        event.summary(DEFAULT_EVENT_TITLE);
-    }
-    if let Some(desc) = params.get("desc") {
-        event.description(desc);
-    } else {
-        event.description("Powered by zerocal.shuttleapp.rs");
-    }
-
-    match params.get("start") {
-        Some(start) if !start.is_empty() => {
-            let start = match parse_time(start) {
-                Ok(start) => start,
-                Err(e) => {
-                    return bad_request(format!("Invalid start time: {}", e));
-                }
-            };
-            event.starts(start);
-            if let Some(duration) = params.get("duration") {
-                let duration = match parse_duration(duration) {
-                    Ok(duration) => duration,
-                    Err(e) => {
-                        return bad_request(format!("Invalid duration: {}", e));
-                    }
-                };
-                event.ends(start + duration);
-            }
-        }
-        _ => {
-            // start is not set or empty; default to 1 hour event
-            event.starts(chrono::Utc::now());
-            event.ends(chrono::Utc::now() + chrono::Duration::hours(1));
-        }
-    }
-
-    match params.get("end") {
-        Some(end) if !end.is_empty() => {
-            let end = match parse_time(end) {
-                Ok(end) => end,
-                Err(e) => {
-                    return bad_request(format!("Invalid end time: {}", e));
-                }
-            };
-            event.ends(end);
-            if let Some(duration) = params.get("duration") {
-                if params.get("start").is_none() {
-                    // If only duration is given but no start, set start to end - duration
-                    let duration = match parse_duration(duration) {
-                        Ok(duration) => duration,
-                        Err(e) => {
-                            return bad_request(format!("Invalid duration: {}", e));
-                        }
-                    };
-                    event.starts(end - duration);
-                }
-            }
-        }
-        _ => {
-            // end is not set or empty; default to 1 hour event
-            // TODO: handle case where start is set
-            event.starts(chrono::Utc::now());
-            event.ends(chrono::Utc::now() + chrono::Duration::hours(1));
-        }
-    }
-
-    if let Some(location) = params.get("location") {
-        event.location(location);
-    }
-
-    let ical = Calendar::new().push(event.done()).done();
+    let ical = match cal::create_calendar(params) {
+        Ok(cal) => cal,
+        Err(e) => { return bad_request(e.err); }
+    };
 
     CalendarResponse(ical).into_response()
+}
+
+pub fn get_router() -> Router {
+    Router::new()
+        .route("/qr", get(qr))
+        .route("/", get(calendar))
+        .route("/", post(calendar))
 }
 
 // cfg if shuttle feature is enabled
 #[cfg(feature = "shuttle")]
 #[shuttle_service::main]
 async fn axum() -> shuttle_service::ShuttleAxum {
-    let router = Router::new()
-        .route("/", get(calendar))
-        .route("/", post(calendar));
+    let router = get_router();
     let sync_wrapper = SyncWrapper::new(router);
 
     Ok(sync_wrapper)

--- a/src/time.rs
+++ b/src/time.rs
@@ -9,12 +9,11 @@ pub(crate) fn parse_duration(duration: &str) -> Result<Duration> {
 
 /// Helper function to parse all supported time formats
 pub(crate) fn parse_time(time: &str) -> Result<chrono::DateTime<chrono::Utc>> {
-    match dateparser::parse(time) {
-        Ok(date) => Ok(date),
-        Err(_) => {
-            let time = chrono::NaiveDateTime::parse_from_str(time, "%Y-%m-%dT%H:%M")
-                .context("Invalid time format. Please use ISO 8601 or RFC 3339 format.")?;
-            Ok(chrono::DateTime::<chrono::Utc>::from_utc(time, chrono::Utc))
-        }
+    if let Ok(date) = dateparser::parse(time) {
+        Ok(date)
+    } else {
+        let time = chrono::NaiveDateTime::parse_from_str(time, "%Y-%m-%dT%H:%M")
+            .context("Invalid time format. Please use ISO 8601 or RFC 3339 format.")?;
+        Ok(chrono::DateTime::<chrono::Utc>::from_utc(time, chrono::Utc))
     }
 }

--- a/static/index.html
+++ b/static/index.html
@@ -48,9 +48,11 @@
             });
 
         // set #link to the new URL
-        document.querySelector("#link").href = location + "?" + paramsFiltered.join("&");
-        // set #link to the new URL
-        document.querySelector("#link").text = location + "?" + paramsFiltered.join("&");
+        const newUrl = location + "?" + paramsFiltered.join("&");
+        const qrUrl = location + "qr?" + paramsFiltered.join("&");
+        document.querySelector("#link").href = newUrl;
+        document.querySelector("#link").text = newUrl;
+        document.querySelector("#qr").src = qrUrl;
 
         const terminalSimple = `curl '${location}?${paramsFiltered.join("&")}'`;
         document.getElementById("curl-simple").textContent = terminalSimple;
@@ -153,6 +155,8 @@
             <strong>You can also share a direct link to the calendar event:</strong>
             <p>
               <a href="" id="link"></a>
+              </br>
+              <img src="" id="qr"></img>
             </p>
           </p>
         </li>


### PR DESCRIPTION
Fixes #13 
## Changes
* Uses `qrcode-generator` crate.
* Cross-service (local/shuttle) router creation, to avoid updates in two places.
* Moved calendar generation to new file `cal.rs` to allow reuse between qr generation and normal function.
* Fixed clippy complaining about a `match` which could have been an `if let`.


## Design
### Decisions
* Exports images as PNG for better compatibility (HTML image embedding didn't work with SVG), plus smaller file sizes (<2KB, compared to ~200KB for SVG).
* QR generation is handled by a new endpoint `/qr`, for continued ease of use with `curl` etc., plus this allows people to share links to images rather than the image itself if desired.
* QR contains embedded calendar event, rather than a link back to the app to generate the event.
* QR code has medium ECC - not personally sure if this is correct, we could go lower for smaller codes.
### UI/UX
QR code is tucked beneath the link to the calendar invite:
![image](https://user-images.githubusercontent.com/65562885/201472728-b71611be-c3da-4723-abb6-cfdd73fb5a75.png)

QR code directly produces a calendar event on both Android and iOS:
Android | iOS
-----------|-------
![image](https://user-images.githubusercontent.com/65562885/201472784-b5e0a968-2037-4454-b6a4-3927dc5e5ec9.png)|![image](https://user-images.githubusercontent.com/65562885/201478028-7213d0ae-021c-4a76-ac39-26b9c922382e.png)


